### PR TITLE
fix: do not ignore true specification when combining using OR operator

### DIFF
--- a/src/Expressions/Common/EnumerableExtensions.cs
+++ b/src/Expressions/Common/EnumerableExtensions.cs
@@ -1,0 +1,23 @@
+﻿namespace Raiqub.Expressions.Common;
+
+internal static class EnumerableExtensions
+{
+    public static TSource? AggregateOrDefault<TSource>(
+        this IEnumerable<TSource> source,
+        Func<TSource, TSource, TSource> func)
+    {
+        using IEnumerator<TSource> e = source.GetEnumerator();
+        if (!e.MoveNext())
+        {
+            return default;
+        }
+
+        TSource result = e.Current;
+        while (e.MoveNext())
+        {
+            result = func(result, e.Current);
+        }
+
+        return result;
+    }
+}

--- a/src/Expressions/Expressions.csproj
+++ b/src/Expressions/Expressions.csproj
@@ -8,4 +8,8 @@
     </PackageTags>
   </PropertyGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Raiqub.Expressions.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Expressions/Internal/ExpressionTreeExtensions.cs
+++ b/src/Expressions/Internal/ExpressionTreeExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq.Expressions;
+using Raiqub.Expressions.Common;
 
 namespace Raiqub.Expressions.Internal;
 
@@ -8,6 +9,11 @@ internal static class ExpressionTreeExtensions
     {
         var rightParam = right.Parameters.Single();
         var leftParam = left.Parameters.Single();
+        if (IsTrueExpression(left))
+            return right;
+        if (IsTrueExpression(right))
+            return left;
+
 
         var newRight = new ReplaceParameterExpressionVisitor(rightParam, leftParam)
             .VisitAndConvert(right.Body, nameof(Expression.AndAlso));
@@ -20,7 +26,7 @@ internal static class ExpressionTreeExtensions
     {
         return expressions.Aggregate(
             AllSpecification<T>.s_expression,
-            static (x, y) => ReferenceEquals(x, AllSpecification<T>.s_expression) ? y : x.And(y));
+            static (x, y) => x.And(y));
     }
 
     public static Expression<Func<TDerived, bool>> CastDown<TParent, TDerived>(
@@ -36,6 +42,11 @@ internal static class ExpressionTreeExtensions
         return Expression.Lambda<Func<TDerived, bool>>(newBody, newParam);
     }
 
+    public static bool IsTrueExpression<T>(this Expression<Func<T, bool>> expression)
+    {
+        return expression.Body is ConstantExpression { Value: true };
+    }
+
     public static Expression<Func<T, bool>> Not<T>(this Expression<Func<T, bool>> expression)
     {
         var leftParam = expression.Parameters.Single();
@@ -48,6 +59,9 @@ internal static class ExpressionTreeExtensions
     {
         var rightParam = right.Parameters.Single();
         var leftParam = left.Parameters.Single();
+        if (IsTrueExpression(left) || IsTrueExpression(right))
+            return AllSpecification<T>.s_expression;
+
 
         var newRight = new ReplaceParameterExpressionVisitor(rightParam, leftParam)
             .VisitAndConvert(right.Body, nameof(Expression.OrElse));
@@ -58,8 +72,6 @@ internal static class ExpressionTreeExtensions
 
     public static Expression<Func<T, bool>> Or<T>(this IEnumerable<Expression<Func<T, bool>>> expressions)
     {
-        return expressions.Aggregate(
-            AllSpecification<T>.s_expression,
-            static (x, y) => ReferenceEquals(x, AllSpecification<T>.s_expression) ? y : x.Or(y));
+        return expressions.AggregateOrDefault(static (x, y) => x.Or(y)) ?? AllSpecification<T>.s_expression;
     }
 }

--- a/src/Expressions/Internal/ExpressionTreeExtensions.cs
+++ b/src/Expressions/Internal/ExpressionTreeExtensions.cs
@@ -7,13 +7,13 @@ internal static class ExpressionTreeExtensions
 {
     public static Expression<Func<T, bool>> And<T>(this Expression<Func<T, bool>> left, Expression<Func<T, bool>> right)
     {
-        var rightParam = right.Parameters.Single();
-        var leftParam = left.Parameters.Single();
         if (IsTrueExpression(left))
             return right;
         if (IsTrueExpression(right))
             return left;
 
+        var rightParam = right.Parameters.Single();
+        var leftParam = left.Parameters.Single();
 
         var newRight = new ReplaceParameterExpressionVisitor(rightParam, leftParam)
             .VisitAndConvert(right.Body, nameof(Expression.AndAlso));
@@ -57,11 +57,11 @@ internal static class ExpressionTreeExtensions
 
     public static Expression<Func<T, bool>> Or<T>(this Expression<Func<T, bool>> left, Expression<Func<T, bool>> right)
     {
-        var rightParam = right.Parameters.Single();
-        var leftParam = left.Parameters.Single();
         if (IsTrueExpression(left) || IsTrueExpression(right))
             return AllSpecification<T>.s_expression;
 
+        var rightParam = right.Parameters.Single();
+        var leftParam = left.Parameters.Single();
 
         var newRight = new ReplaceParameterExpressionVisitor(rightParam, leftParam)
             .VisitAndConvert(right.Body, nameof(Expression.OrElse));

--- a/src/Expressions/Specification.cs
+++ b/src/Expressions/Specification.cs
@@ -32,9 +32,9 @@ public static class Specification
     /// <returns>A new specification that represents the conjunction of two specifications (both must be satisfied).</returns>
     public static Specification<T> And<T>(this Specification<T> left, Specification<T> right)
     {
-        if (ReferenceEquals(left, AllSpecification<T>.Instance))
+        if (left.IsTrueExpression())
             return right;
-        if (ReferenceEquals(right, AllSpecification<T>.Instance))
+        if (right.IsTrueExpression())
             return left;
         return new AnonymousSpecification<T>(left.ToExpression().And(right.ToExpression()));
     }
@@ -75,8 +75,7 @@ public static class Specification
     /// <returns>A new specification that represents the disjunction of two specifications (at least one of them must be satisfied).</returns>
     public static Specification<T> Or<T>(this Specification<T> left, Specification<T> right)
     {
-        return ReferenceEquals(left, AllSpecification<T>.Instance) ||
-               ReferenceEquals(right, AllSpecification<T>.Instance)
+        return left.IsTrueExpression() || right.IsTrueExpression()
             ? AllSpecification<T>.Instance
             : new AnonymousSpecification<T>(left.ToExpression().Or(right.ToExpression()));
     }

--- a/src/Expressions/Specification{T}.cs
+++ b/src/Expressions/Specification{T}.cs
@@ -54,4 +54,6 @@ public abstract class Specification<T>
 
     /// <summary>Returns a string representation of the lambda expression.</summary>
     public override string ToString() => ToExpression().ToString();
+
+    internal bool IsTrueExpression() => ToExpression().IsTrueExpression();
 }

--- a/tests/Expressions.Tests/Internal/ExpressionTreeExtensionsTest.cs
+++ b/tests/Expressions.Tests/Internal/ExpressionTreeExtensionsTest.cs
@@ -1,0 +1,34 @@
+﻿using System.Linq.Expressions;
+using FluentAssertions;
+using Raiqub.Expressions.Internal;
+
+namespace Raiqub.Expressions.Tests.Internal;
+
+public class ExpressionTreeExtensionsTest
+{
+    [Fact]
+    public void AndShouldIgnoreAllSpecifications()
+    {
+        Expression<Func<string, bool>> trueExpr = s => true;
+        Expression<Func<string, bool>> isJohnExpr = s => s == "john";
+
+        var spec1 = trueExpr.And(isJohnExpr);
+        var spec2 = isJohnExpr.And(trueExpr);
+
+        spec1.Should().BeSameAs(isJohnExpr);
+        spec2.Should().BeSameAs(isJohnExpr);
+    }
+
+    [Fact]
+    public void OrShouldOptimizeAllSpecifications()
+    {
+        Expression<Func<string, bool>> customSpec = s => true;
+        Expression<Func<string, bool>> isJohnSpec = s => s == "john";
+
+        var spec1 = customSpec.Or(isJohnSpec);
+        var spec2 = isJohnSpec.Or(customSpec);
+
+        spec1.Should().BeSameAs(AllSpecification<string>.s_expression);
+        spec2.Should().BeSameAs(AllSpecification<string>.s_expression);
+    }
+}

--- a/tests/Expressions.Tests/SpecificationTest.cs
+++ b/tests/Expressions.Tests/SpecificationTest.cs
@@ -62,6 +62,24 @@ public class SpecificationTest
     }
 
     [Fact]
+    public void AndShouldIgnoreAllSpecifications()
+    {
+        var staticSpec = Specification.All<string>();
+        var customSpec = Specification.Create((string s) => true);
+        var isJohnSpec = Specification.Create((string s) => s == "john");
+
+        var spec1 = staticSpec.And(isJohnSpec);
+        var spec2 = customSpec.And(isJohnSpec);
+        var spec3 = isJohnSpec.And(staticSpec);
+        var spec4 = isJohnSpec.And(customSpec);
+
+        spec1.Should().BeSameAs(isJohnSpec);
+        spec2.Should().BeSameAs(isJohnSpec);
+        spec3.Should().BeSameAs(isJohnSpec);
+        spec4.Should().BeSameAs(isJohnSpec);
+    }
+
+    [Fact]
     public void AndShouldEvaluateCollectionCorrectly()
     {
         var specification = Specification.And(
@@ -104,6 +122,24 @@ public class SpecificationTest
 
         bool result = specification.IsSatisfiedBy(input);
         result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void OrShouldOptimizeAllSpecifications()
+    {
+        var staticSpec = Specification.All<string>();
+        var customSpec = Specification.Create((string s) => true);
+        var isJohnSpec = Specification.Create((string s) => s == "john");
+
+        var spec1 = staticSpec.Or(isJohnSpec);
+        var spec2 = customSpec.Or(isJohnSpec);
+        var spec3 = isJohnSpec.Or(staticSpec);
+        var spec4 = isJohnSpec.Or(customSpec);
+
+        spec1.Should().BeSameAs(staticSpec);
+        spec2.Should().BeSameAs(staticSpec);
+        spec3.Should().BeSameAs(staticSpec);
+        spec4.Should().BeSameAs(staticSpec);
     }
 
     [Theory]

--- a/tests/Expressions.Tests/SpecificationTest.cs
+++ b/tests/Expressions.Tests/SpecificationTest.cs
@@ -143,6 +143,29 @@ public class SpecificationTest
         result4.Should().BeFalse();
     }
 
+    [Fact]
+    public void OrShouldReturnTrueWhenAnyIsTrue()
+    {
+        var specification1 = Specification.Or(
+            Specification.Create<string>(s => false),
+            Specification.Create<string>(s => false),
+            Specification.All<string>(),
+            Specification.Create<string>(s => false),
+            Specification.Create<string>(s => false));
+        var specification2 = Specification.Or(
+            Specification.Create<string>(s => false),
+            Specification.Create<string>(s => false),
+            Specification.Create<string>(s => true),
+            Specification.Create<string>(s => false),
+            Specification.Create<string>(s => false));
+
+        bool result1 = specification1.IsSatisfiedBy("");
+        bool result2 = specification2.IsSatisfiedBy("");
+
+        result1.Should().BeTrue();
+        result2.Should().BeTrue();
+    }
+
     [Theory]
     [InlineData("John Dee")]
     [InlineData("john moor")]


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed
- Combining a collection of `Specification` using OR operator fails when it has an operand created from `Specification.All` method

## Details on the issue fix or feature implementation
- Combine operands not ignoring the anyone created from `Specification.All` method
- Improve checking of "true expression" by parsing the expression body

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
