### PR TITLE
test: Optimize code and improve tests of Expressions

### DIFF
--- a/src/Expressions/Common/EnumerableExtensions.cs
+++ b/src/Expressions/Common/EnumerableExtensions.cs
@@ -2,14 +2,15 @@
 
 internal static class EnumerableExtensions
 {
-    public static TSource? AggregateOrDefault<TSource>(
+    public static TSource AggregateOrDefault<TSource>(
         this IEnumerable<TSource> source,
-        Func<TSource, TSource, TSource> func)
+        Func<TSource, TSource, TSource> func,
+        TSource defaultValue)
     {
         using IEnumerator<TSource> e = source.GetEnumerator();
         if (!e.MoveNext())
         {
-            return default;
+            return defaultValue;
         }
 
         TSource result = e.Current;

--- a/src/Expressions/Internal/ExpressionTreeExtensions.cs
+++ b/src/Expressions/Internal/ExpressionTreeExtensions.cs
@@ -12,28 +12,26 @@ internal static class ExpressionTreeExtensions
         if (IsTrueExpression(right))
             return left;
 
-        var rightParam = right.Parameters.Single();
-        var leftParam = left.Parameters.Single();
+        var rightParam = right.Parameters[0];
+        var leftParam = left.Parameters[0];
 
         var newRight = new ReplaceParameterExpressionVisitor(rightParam, leftParam)
             .VisitAndConvert(right.Body, nameof(Expression.AndAlso));
 
         var andExpression = Expression.AndAlso(left.Body, newRight);
-        return Expression.Lambda<Func<T, bool>>(andExpression, leftParam);
+        return Expression.Lambda<Func<T, bool>>(andExpression, left.Parameters);
     }
 
     public static Expression<Func<T, bool>> And<T>(this IEnumerable<Expression<Func<T, bool>>> expressions)
     {
-        return expressions.Aggregate(
-            AllSpecification<T>.s_expression,
-            static (x, y) => x.And(y));
+        return expressions.AggregateOrDefault(static (x, y) => x.And(y), AllSpecification<T>.s_expression);
     }
 
     public static Expression<Func<TDerived, bool>> CastDown<TParent, TDerived>(
         this Expression<Func<TParent, bool>> expression)
         where TDerived : class, TParent
     {
-        var originalParam = expression.Parameters.Single();
+        var originalParam = expression.Parameters[0];
         var newParam = Expression.Parameter(typeof(TDerived), originalParam.Name);
 
         Expression newBody = new ReplaceParameterExpressionVisitor(originalParam, newParam)
@@ -49,10 +47,8 @@ internal static class ExpressionTreeExtensions
 
     public static Expression<Func<T, bool>> Not<T>(this Expression<Func<T, bool>> expression)
     {
-        var leftParam = expression.Parameters.Single();
-
         var notExpression = Expression.Not(expression.Body);
-        return Expression.Lambda<Func<T, bool>>(notExpression, leftParam);
+        return Expression.Lambda<Func<T, bool>>(notExpression, expression.Parameters);
     }
 
     public static Expression<Func<T, bool>> Or<T>(this Expression<Func<T, bool>> left, Expression<Func<T, bool>> right)
@@ -60,18 +56,18 @@ internal static class ExpressionTreeExtensions
         if (IsTrueExpression(left) || IsTrueExpression(right))
             return AllSpecification<T>.s_expression;
 
-        var rightParam = right.Parameters.Single();
-        var leftParam = left.Parameters.Single();
+        var rightParam = right.Parameters[0];
+        var leftParam = left.Parameters[0];
 
         var newRight = new ReplaceParameterExpressionVisitor(rightParam, leftParam)
             .VisitAndConvert(right.Body, nameof(Expression.OrElse));
 
         var andExpression = Expression.OrElse(left.Body, newRight);
-        return Expression.Lambda<Func<T, bool>>(andExpression, leftParam);
+        return Expression.Lambda<Func<T, bool>>(andExpression, left.Parameters);
     }
 
     public static Expression<Func<T, bool>> Or<T>(this IEnumerable<Expression<Func<T, bool>>> expressions)
     {
-        return expressions.AggregateOrDefault(static (x, y) => x.Or(y)) ?? AllSpecification<T>.s_expression;
+        return expressions.AggregateOrDefault(static (x, y) => x.Or(y), AllSpecification<T>.s_expression);
     }
 }

--- a/src/Expressions/Internal/ExpressionTreeExtensions.cs
+++ b/src/Expressions/Internal/ExpressionTreeExtensions.cs
@@ -7,9 +7,9 @@ internal static class ExpressionTreeExtensions
 {
     public static Expression<Func<T, bool>> And<T>(this Expression<Func<T, bool>> left, Expression<Func<T, bool>> right)
     {
-        if (IsTrueExpression(left))
+        if (IsTrueConstant(left))
             return right;
-        if (IsTrueExpression(right))
+        if (IsTrueConstant(right))
             return left;
 
         var rightParam = right.Parameters[0];
@@ -40,7 +40,7 @@ internal static class ExpressionTreeExtensions
         return Expression.Lambda<Func<TDerived, bool>>(newBody, newParam);
     }
 
-    public static bool IsTrueExpression<T>(this Expression<Func<T, bool>> expression)
+    public static bool IsTrueConstant<T>(this Expression<Func<T, bool>> expression)
     {
         return expression.Body is ConstantExpression { Value: true };
     }
@@ -53,7 +53,7 @@ internal static class ExpressionTreeExtensions
 
     public static Expression<Func<T, bool>> Or<T>(this Expression<Func<T, bool>> left, Expression<Func<T, bool>> right)
     {
-        if (IsTrueExpression(left) || IsTrueExpression(right))
+        if (IsTrueConstant(left) || IsTrueConstant(right))
             return AllSpecification<T>.s_expression;
 
         var rightParam = right.Parameters[0];

--- a/src/Expressions/Specification.cs
+++ b/src/Expressions/Specification.cs
@@ -45,9 +45,10 @@ public static class Specification
     /// <returns>A new specification that represents the conjunction of all specifications (all must be satisfied).</returns>
     public static Specification<T> And<T>(IEnumerable<Specification<T>> specifications)
     {
-        return ReferenceEquals(specifications, Enumerable.Empty<Specification<T>>())
+        var expression = specifications.Select(static s => s.ToExpression()).And();
+        return expression.IsTrueExpression()
             ? AllSpecification<T>.Instance
-            : new AnonymousSpecification<T>(specifications.Select(static s => s.ToExpression()).And());
+            : new AnonymousSpecification<T>(expression);
     }
 
     /// <summary>Combines multiple specifications using the conditional logical AND operator.</summary>
@@ -75,9 +76,10 @@ public static class Specification
     /// <returns>A new specification that represents the disjunction of two specifications (at least one of them must be satisfied).</returns>
     public static Specification<T> Or<T>(this Specification<T> left, Specification<T> right)
     {
-        return left.IsTrueExpression() || right.IsTrueExpression()
+        var expression = left.ToExpression().Or(right.ToExpression());
+        return expression.IsTrueExpression()
             ? AllSpecification<T>.Instance
-            : new AnonymousSpecification<T>(left.ToExpression().Or(right.ToExpression()));
+            : new AnonymousSpecification<T>(expression);
     }
 
     /// <summary>Combines multiple specifications using the conditional logical OR operator.</summary>
@@ -86,9 +88,10 @@ public static class Specification
     /// <returns>A new specification that represents the disjunction of all specifications (at least one of them must be satisfied).</returns>
     public static Specification<T> Or<T>(IEnumerable<Specification<T>> specifications)
     {
-        return ReferenceEquals(specifications, Enumerable.Empty<Specification<T>>())
+        var expression = specifications.Select(static s => s.ToExpression()).Or();
+        return expression.IsTrueExpression()
             ? AllSpecification<T>.Instance
-            : new AnonymousSpecification<T>(specifications.Select(static s => s.ToExpression()).Or());
+            : new AnonymousSpecification<T>(expression);
     }
 
     /// <summary>Combines multiple specifications using the conditional logical OR operator.</summary>

--- a/src/Expressions/Specification.cs
+++ b/src/Expressions/Specification.cs
@@ -46,7 +46,7 @@ public static class Specification
     public static Specification<T> And<T>(IEnumerable<Specification<T>> specifications)
     {
         var expression = specifications.Select(static s => s.ToExpression()).And();
-        return expression.IsTrueExpression()
+        return expression.IsTrueConstant()
             ? AllSpecification<T>.Instance
             : new AnonymousSpecification<T>(expression);
     }
@@ -77,7 +77,7 @@ public static class Specification
     public static Specification<T> Or<T>(this Specification<T> left, Specification<T> right)
     {
         var expression = left.ToExpression().Or(right.ToExpression());
-        return expression.IsTrueExpression()
+        return expression.IsTrueConstant()
             ? AllSpecification<T>.Instance
             : new AnonymousSpecification<T>(expression);
     }
@@ -89,7 +89,7 @@ public static class Specification
     public static Specification<T> Or<T>(IEnumerable<Specification<T>> specifications)
     {
         var expression = specifications.Select(static s => s.ToExpression()).Or();
-        return expression.IsTrueExpression()
+        return expression.IsTrueConstant()
             ? AllSpecification<T>.Instance
             : new AnonymousSpecification<T>(expression);
     }

--- a/src/Expressions/Specification{T}.cs
+++ b/src/Expressions/Specification{T}.cs
@@ -55,5 +55,5 @@ public abstract class Specification<T>
     /// <summary>Returns a string representation of the lambda expression.</summary>
     public override string ToString() => ToExpression().ToString();
 
-    internal bool IsTrueExpression() => ToExpression().IsTrueExpression();
+    internal bool IsTrueExpression() => ToExpression().IsTrueConstant();
 }

--- a/tests/Expressions.Tests/Common/TheoryBuilder.cs
+++ b/tests/Expressions.Tests/Common/TheoryBuilder.cs
@@ -1,0 +1,15 @@
+﻿namespace Raiqub.Expressions.Tests.Common;
+
+public static class TheoryBuilder
+{
+    public static TheoryData<T> Build<T>(params T[] values)
+    {
+        var theoryData = new TheoryData<T>();
+        foreach (T value in values)
+        {
+            theoryData.Add(value);
+        }
+
+        return theoryData;
+    }
+}

--- a/tests/Expressions.Tests/SpecificationEnumerableExtensionsTest.cs
+++ b/tests/Expressions.Tests/SpecificationEnumerableExtensionsTest.cs
@@ -1,0 +1,217 @@
+﻿using FluentAssertions;
+using Raiqub.Expressions.Tests.Common;
+
+namespace Raiqub.Expressions.Tests;
+
+public class SpecificationEnumerableExtensionsTest
+{
+    private static readonly Random s_random = new(1447398856);
+
+    public static IEnumerable<string> RandomWords1 => new[]
+    {
+        "computer", "shower", "auditor", "beam", "joy", "similar", "inch", "access", "acute", "evoke", "pitch",
+        "planet", "pudding", "directory", "rider"
+    };
+
+    public static IEnumerable<string> RandomWords2 => new[]
+    {
+        "sanctuary", "traction", "finance", "promotion", "peel", "illusion", "domination", "turkey", "relate",
+        "change", "software", "economist", "attention", "ribbon", "pierce"
+    };
+
+    public static IEnumerable<string> RandomWords1Big => RandomWords1
+        .Concat(RandomWords1.OrderBy(_ => s_random.Next()))
+        .Concat(RandomWords1.OrderBy(_ => s_random.Next()))
+        .Concat(RandomWords1.OrderBy(_ => s_random.Next()))
+        .Concat(RandomWords1.OrderBy(_ => s_random.Next()))
+        .OrderBy(_ => s_random.Next());
+
+    public static TheoryData<string> WordsIn1 => TheoryBuilder.Build(RandomWords1.ToArray());
+    public static TheoryData<string> WordsIn2 => TheoryBuilder.Build(RandomWords2.ToArray());
+
+    [Theory]
+    [MemberData(nameof(WordsIn1))]
+    public void AnyShouldBeTrueWhenMatchFound(string word)
+    {
+        bool hasWord = RandomWords1.Any(Specification.Create<string>(s => s == word));
+
+        hasWord.Should().BeTrue();
+    }
+
+    [Theory]
+    [MemberData(nameof(WordsIn2))]
+    public void AnyShouldBeFalseWhenMatchNotFound(string word)
+    {
+        bool hasWord = RandomWords1.Any(Specification.Create<string>(s => s == word));
+
+        hasWord.Should().BeFalse();
+    }
+
+    [Theory]
+    [MemberData(nameof(WordsIn1))]
+    public void AnyShouldBeFalseWhenCollectionIsEmpty(string word)
+    {
+        bool hasWord = Enumerable.Empty<string>().Any(Specification.Create<string>(s => s == word));
+
+        hasWord.Should().BeFalse();
+    }
+
+    [Theory]
+    [MemberData(nameof(WordsIn1))]
+    public void CountShouldReturnExpectedWhenMatchFound(string word)
+    {
+        int count1 = RandomWords1.Count(Specification.Create<string>(s => s == word));
+        int count2 = RandomWords1Big.Count(Specification.Create<string>(s => s == word));
+
+        count1.Should().Be(1);
+        count2.Should().Be(5);
+    }
+
+    [Theory]
+    [MemberData(nameof(WordsIn2))]
+    public void CountShouldBeZeroWhenMatchNotFound(string word)
+    {
+        int count = RandomWords1Big.Count(Specification.Create<string>(s => s == word));
+
+        count.Should().Be(0);
+    }
+
+    [Theory]
+    [MemberData(nameof(WordsIn1))]
+    public void CountShouldBeZeroWhenCollectionIsEmpty(string word)
+    {
+        int count = Enumerable.Empty<string>().Count(Specification.Create<string>(s => s == word));
+
+        count.Should().Be(0);
+    }
+
+    [Theory]
+    [MemberData(nameof(WordsIn1))]
+    public void FirstShouldReturnExpectedWhenMatchFound(string word)
+    {
+        string found1 = RandomWords1.First(Specification.Create<string>(s => s == word));
+        string found2 = RandomWords1Big.First(Specification.Create<string>(s => s == word));
+
+        found1.Should().Be(word);
+        found2.Should().Be(word);
+    }
+
+    [Theory]
+    [MemberData(nameof(WordsIn2))]
+    public void FirstShouldThrowWhenMatchNotFound(string word)
+    {
+        Action first = () => RandomWords1Big.First(Specification.Create<string>(s => s == word));
+
+        first.Should().ThrowExactly<InvalidOperationException>();
+    }
+
+    [Theory]
+    [MemberData(nameof(WordsIn1))]
+    public void FirstShouldThrowWhenCollectionIsEmpty(string word)
+    {
+        Action first = () => Enumerable.Empty<string>().First(Specification.Create<string>(s => s == word));
+
+        first.Should().ThrowExactly<InvalidOperationException>();
+    }
+
+    [Theory]
+    [MemberData(nameof(WordsIn1))]
+    public void FirstOrDefaultShouldReturnExpectedWhenMatchFound(string word)
+    {
+        string? found1 = RandomWords1.FirstOrDefault(Specification.Create<string>(s => s == word));
+        string? found2 = RandomWords1Big.FirstOrDefault(Specification.Create<string>(s => s == word));
+
+        found1.Should().Be(word);
+        found2.Should().Be(word);
+    }
+
+    [Theory]
+    [MemberData(nameof(WordsIn2))]
+    public void FirstOrDefaultShouldThrowWhenMatchNotFound(string word)
+    {
+        string? found = RandomWords1Big.FirstOrDefault(Specification.Create<string>(s => s == word));
+
+        found.Should().BeNull();
+    }
+
+    [Theory]
+    [MemberData(nameof(WordsIn1))]
+    public void FirstOrDefaultShouldThrowWhenCollectionIsEmpty(string word)
+    {
+        string? found = Enumerable.Empty<string>().FirstOrDefault(Specification.Create<string>(s => s == word));
+
+        found.Should().BeNull();
+    }
+
+    [Theory]
+    [MemberData(nameof(WordsIn1))]
+    public void SingleShouldReturnExpectedWhenSingleMatchIsFound(string word)
+    {
+        string found = RandomWords1.Single(Specification.Create<string>(s => s == word));
+
+        found.Should().Be(word);
+    }
+
+    [Theory]
+    [MemberData(nameof(WordsIn2))]
+    public void SingleShouldThrowWhenMatchNotFound(string word)
+    {
+        Action single = () => RandomWords1.Single(Specification.Create<string>(s => s == word));
+
+        single.Should().ThrowExactly<InvalidOperationException>();
+    }
+
+    [Theory]
+    [MemberData(nameof(WordsIn1))]
+    public void SingleShouldThrowsWhenMultipleMatchesAreFound(string word)
+    {
+        Action single = () => RandomWords1Big.Single(Specification.Create<string>(s => s == word));
+
+        single.Should().ThrowExactly<InvalidOperationException>();
+    }
+
+    [Theory]
+    [MemberData(nameof(WordsIn1))]
+    public void SingleShouldThrowsWhenCollectionIsEmpty(string word)
+    {
+        Action single = () => Enumerable.Empty<string>().Single(Specification.Create<string>(s => s == word));
+
+        single.Should().ThrowExactly<InvalidOperationException>();
+    }
+
+    [Theory]
+    [MemberData(nameof(WordsIn1))]
+    public void SingleOrDefaultShouldReturnExpectedWhenSingleMatchIsFound(string word)
+    {
+        string? found = RandomWords1.SingleOrDefault(Specification.Create<string>(s => s == word));
+
+        found.Should().Be(word);
+    }
+
+    [Theory]
+    [MemberData(nameof(WordsIn2))]
+    public void SingleOrDefaultShouldBeNullWhenMatchNotFound(string word)
+    {
+        string? found = RandomWords1.SingleOrDefault(Specification.Create<string>(s => s == word));
+
+        found.Should().BeNull();
+    }
+
+    [Theory]
+    [MemberData(nameof(WordsIn1))]
+    public void SingleOrDefaultShouldThrowsWhenMultipleMatchesAreFound(string word)
+    {
+        Action single = () => RandomWords1Big.SingleOrDefault(Specification.Create<string>(s => s == word));
+
+        single.Should().ThrowExactly<InvalidOperationException>();
+    }
+
+    [Theory]
+    [MemberData(nameof(WordsIn1))]
+    public void SingleOrDefaultShouldThrowsWhenCollectionIsEmpty(string word)
+    {
+        string? found = Enumerable.Empty<string>().SingleOrDefault(Specification.Create<string>(s => s == word));
+
+        found.Should().BeNull();
+    }
+}

--- a/tests/Expressions.Tests/SpecificationOfTTest.cs
+++ b/tests/Expressions.Tests/SpecificationOfTTest.cs
@@ -142,4 +142,16 @@ public class SpecificationOfTTest
         result1.Should().BeTrue();
         result2.Should().BeFalse();
     }
+
+    [Fact]
+    public void IsSatisfiedByShouldCacheCompilation()
+    {
+        var specification = new OneTimeSpecification<string>(s => s == "john");
+
+        bool isTrue = specification.IsSatisfiedBy("john");
+        bool isFalse = specification.IsSatisfiedBy("jane");
+
+        isTrue.Should().BeTrue();
+        isFalse.Should().BeFalse();
+    }
 }

--- a/tests/Expressions.Tests/SpecificationTest.cs
+++ b/tests/Expressions.Tests/SpecificationTest.cs
@@ -61,6 +61,22 @@ public class SpecificationTest
         result2.Should().BeTrue();
     }
 
+    [Theory]
+    [InlineData("John Dee")]
+    [InlineData("john dee")]
+    [InlineData("johndee")]
+    public void AndShouldReturnSingleElementFromCollection(string input)
+    {
+        var specification1 = Specification.And(
+            Specification.Create((string s) => s.Contains("john", StringComparison.OrdinalIgnoreCase)));
+
+        bool result1 = specification1.IsSatisfiedBy(input);
+        bool result2 = specification1.IsSatisfiedBy(input.Replace("ohn", "ane"));
+
+        result1.Should().BeTrue();
+        result2.Should().BeFalse();
+    }
+
     [Fact]
     public void AndShouldIgnoreAllSpecifications()
     {
@@ -156,6 +172,22 @@ public class SpecificationTest
 
         result1.Should().BeTrue();
         result2.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("John Dee")]
+    [InlineData("john dee")]
+    [InlineData("johndee")]
+    public void OrShouldReturnSingleElementFromCollection(string input)
+    {
+        var specification1 = Specification.Or(
+            Specification.Create((string s) => s.Contains("john", StringComparison.OrdinalIgnoreCase)));
+
+        bool result1 = specification1.IsSatisfiedBy(input);
+        bool result2 = specification1.IsSatisfiedBy(input.Replace("ohn", "ane"));
+
+        result1.Should().BeTrue();
+        result2.Should().BeFalse();
     }
 
     [Fact]

--- a/tests/Expressions.Tests/Stubs/OneTimeSpecification.cs
+++ b/tests/Expressions.Tests/Stubs/OneTimeSpecification.cs
@@ -1,0 +1,21 @@
+﻿using System.Linq.Expressions;
+
+namespace Raiqub.Expressions.Tests.Stubs;
+
+public class OneTimeSpecification<T> : Specification<T>
+{
+    private readonly Expression<Func<T, bool>> _expression;
+    private int _count;
+
+    public OneTimeSpecification(Expression<Func<T, bool>> expression)
+    {
+        _expression = expression;
+    }
+
+    public override Expression<Func<T, bool>> ToExpression()
+    {
+        return _count++ == 0
+            ? _expression
+            : throw new InvalidOperationException();
+    }
+}


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed
- #42

## Details on the issue fix or feature implementation
- Optimize to get first `Expression` parameter using indexer instead of `Single` method
- Optimize to not allocate another `Expression` parameters array when combining expressions
- Optimize to not allocate `Specification` when combination results in a true constant
- Cover 100% of the Expressions project code
- Kill 100% of the Expressions project mutants

## Confirm the following
- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
