### PR TITLE
Fix run condition for mutation test

### DIFF
--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -6,10 +6,10 @@ name: Mutation Test
 on:
   push:
     branches: [ "main" ]
-    paths: [ "src/**/packages.lock.json", "src/**/*.cs", "tests/**/packages.lock.json", "tests/**/*.cs" ]
+    paths: [ "src/**/packages.lock.json", "src/**/*.cs", "tests/**/packages.lock.json", "tests/**/*.cs", ".config/*.json" ]
   pull_request:
     branches: [ "main" ]
-    paths: [ "src/**/packages.lock.json", "src/**/*.cs", "tests/**/packages.lock.json", "tests/**/*.cs" ]
+    paths: [ "src/**/packages.lock.json", "src/**/*.cs", "tests/**/packages.lock.json", "tests/**/*.cs", ".config/*.json" ]
 
 env:
   DOTNET_GENERATE_ASPNET_CERTIFICATE: false


### PR DESCRIPTION
<!-- Thank you for contributing to Raiqub Expressions!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
- Mutation test pipeline do not run when Stryker is updated

## Details on the issue fix or feature implementation
- Add `.config` path to condition to run the mutation test pipeline

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
