### PR TITLE
ci(codeql): run always and support JS

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main" ]
-    paths: [ "src/**/*", "tests/**/*", "docs/**/*" ]
+    paths: [ "src/**", "tests/**", "docs/**", '.github/workflows/codeql.yml' ]
   schedule:
     - cron: '28 20 * * 1'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,11 +14,10 @@ name: "CodeQL"
 on:
   push:
     branches: [ "main" ]
-    paths: [ "src/**/packages.lock.json", "src/**/*.cs", "tests/**/packages.lock.json", "tests/**/*.cs" ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main" ]
-    paths: [ "src/**/packages.lock.json", "src/**/*.cs", "tests/**/packages.lock.json", "tests/**/*.cs" ]
+    paths: [ "src/**/*", "tests/**/*", "docs/**/*" ]
   schedule:
     - cron: '28 20 * * 1'
 
@@ -39,33 +38,44 @@ jobs:
       fail-fast: false
       matrix:
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
-        language: [ 'csharp' ]
+        language: [ 'csharp', 'javascript-typescript' ]
 
     steps:
-    - name: Harden Runner
+    - name: 🛡️ Harden Runner
       uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
       with:
         egress-policy: audit
 
-    - name: Checkout repository
+    - name: 🛒 Checkout repository
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         fetch-depth: 0
 
-    - name: Setup .NET
+    - name: 🧰 Setup .NET
       uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
       with:
         dotnet-version: 6.0.x
+      if: matrix.language == 'csharp'
 
-    - name: Setup NuGet cache
+    - name: 🗃️ Setup NuGet cache
       uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       with:
         path: ~/.nuget/packages
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
         restore-keys: ${{ runner.os }}-nuget-
+      if: matrix.language == 'csharp'
+
+
+    - name: 🧰 Setup Node
+      uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
+      with:
+        node-version: 18
+        cache: npm
+        cache-dependency-path: docs/package-lock.json
+      if: matrix.language == 'javascript-typescript'
 
     # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
+    - name: 🛠️ Initialize CodeQL
       uses: github/codeql-action/init@0b21cf2492b6b02c465a3e5d7c473717ad7721ba # v3.23.1
       with:
         languages: ${{ matrix.language }}
@@ -76,13 +86,25 @@ jobs:
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
-    - name: Restore dependencies
+    - name: 📥 Restore dependencies
       run: dotnet restore --locked-mode
+      if: matrix.language == 'csharp'
 
-    - name: Build
+    - name: 🏗️ Build
       run: dotnet build --no-restore -c Release
+      if: matrix.language == 'csharp'
 
-    - name: Perform CodeQL Analysis
+    - name: 📥 Install dependencies
+      run: npm ci
+      working-directory: docs
+      if: matrix.language == 'javascript-typescript'
+
+    - name: 🏗️ Build with VitePress
+      run: npm run docs:build
+      working-directory: docs
+      if: matrix.language == 'javascript-typescript'
+
+    - name: 🔍 Perform CodeQL Analysis
       uses: github/codeql-action/analyze@0b21cf2492b6b02c465a3e5d7c473717ad7721ba # v3.23.1
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
<!-- Thank you for contributing to Raiqub Expressions!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
- #120

## Details on the issue fix or feature implementation
- Always run CodeQL on main branch
- Support JS for analyzing Vitepress documentation

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
