### PR TITLE
ci: Install both .NET 6 and 8

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -70,6 +70,9 @@ jobs:
     - name: 🧰 Setup .NET
       uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4.0.1
       with:
+        dotnet-version: |
+          6.x
+          8.x
         global-json-file: global.json
       if: matrix.language == 'csharp'
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -50,6 +50,9 @@ jobs:
     - name: 🧰 Setup .NET
       uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4.0.1
       with:
+        dotnet-version: |
+          6.x
+          8.x
         global-json-file: global.json
 
     - name: 🗃️ Setup NuGet cache

--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -49,7 +49,10 @@ jobs:
       - name: 🧰 Setup .NET
         uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4.0.1
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: |
+            6.x
+            8.x
+          global-json-file: global.json
 
       - name: 🗃️ Setup NuGet cache
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2


### PR DESCRIPTION
<!-- Thank you for contributing to Raiqub Expressions!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
- Build workflow failing because of missing .NET 6

## Details on the issue fix or feature implementation
- Ensure that both .NET 6 and 8 are installed

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
